### PR TITLE
sgd gets mail credentials from mail file on globals

### DIFF
--- a/src/shotgunEventDaemon.py
+++ b/src/shotgunEventDaemon.py
@@ -132,6 +132,13 @@ class Config(ConfigParser.ConfigParser):
     def __init__(self, path):
         ConfigParser.ConfigParser.__init__(self)
         self.read(path)
+        # added to handle login credentials for mail more secure
+        lava_mail_config = ConfigParser.ConfigParser()
+        lava_mail_config.read('g:/globals/pipelineConfigs/mail')
+
+        self.server = lava_mail_config.get('pipeline_mail', 'server')
+        self.addr = lava_mail_config.get('pipeline_mail', 'addr')
+        self.pw = lava_mail_config.get('pipeline_mail', 'pw')
 
     def getShotgunURL(self):
         return self.get('shotgun', 'server')
@@ -177,7 +184,7 @@ class Config(ConfigParser.ConfigParser):
         return [s.strip() for s in self.get('plugins', 'paths').split(',')]
 
     def getSMTPServer(self):
-        return self.get('emails', 'server')
+        return self.server
 
     def getSMTPPort(self):
         if self.has_option('emails', 'port'):
@@ -185,23 +192,19 @@ class Config(ConfigParser.ConfigParser):
         return 25
 
     def getFromAddr(self):
-        return self.get('emails', 'from')
+        return self.addr
 
     def getToAddrs(self):
-        return [s.strip() for s in self.get('emails', 'to').split(',')]
+        return self.addr
 
     def getEmailSubject(self):
         return self.get('emails', 'subject')
 
     def getEmailUsername(self):
-        if self.has_option('emails', 'username'):
-            return self.get('emails', 'username')
-        return None
+        return self.addr
 
     def getEmailPassword(self):
-        if self.has_option('emails', 'password'):
-            return self.get('emails', 'password')
-        return None
+        return self.pw
 
     def getSecureSMTP(self):
         if self.has_option('emails', 'useTLS'):


### PR DESCRIPTION
Hey Jonas,
Mit dem PR hier wollte ich dir nurmal zeigen wie ich das mit der Mail im Daemon gemacht hab. Damit das nicht in der config liegt und mit ins repo kommt.

So hatte ich das auch mit den Shotgun credentials gemacht aber das können wir ja so mit nurnoch einem Daemon nicht mehr machen. Aber für das Mails schicken vom Daemon aus können wir das doch so machen oder? Das sollte ja bei allen Daemons gleich sein.

Die Mail die da verschickt wird geht momentan nur ab einem Error Level(30) an mich.